### PR TITLE
fix: [NO-TASK] Get MDS version dynamically

### DIFF
--- a/example/lib/src/storybook/common/widgets/version.dart
+++ b/example/lib/src/storybook/common/widgets/version.dart
@@ -2,13 +2,28 @@ import 'package:flutter/material.dart';
 
 import 'package:moon_design/moon_design.dart';
 
-class MoonVersionWidget extends StatelessWidget {
-  final String version;
+class MoonVersionWidget extends StatefulWidget {
+  const MoonVersionWidget({super.key});
 
-  const MoonVersionWidget({
-    super.key,
-    required this.version,
-  });
+  @override
+  State<MoonVersionWidget> createState() => _MoonVersionWidgetState();
+}
+
+class _MoonVersionWidgetState extends State<MoonVersionWidget> {
+  String? _version = "";
+
+  @override
+  Future<void> didChangeDependencies() async {
+    super.didChangeDependencies();
+
+    final fileContent = await DefaultAssetBundle.of(context).loadString("../pubspec.lock");
+    final entry = fileContent.split("moon_design:")[1].split("version:")[1];
+    final version = RegExp('"(.*?)"').firstMatch(entry)?.group(0)?.replaceAll('"', "");
+
+    setState(() {
+      _version = version;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +41,7 @@ class MoonVersionWidget extends StatelessWidget {
               style: MoonTypography.textStyles.text.text16,
             ),
             const SizedBox(width: 6.0),
-            Text("v$version", style: MoonTypography.textStyles.heading.text16),
+            Text("v$_version", style: MoonTypography.textStyles.heading.text16),
           ],
         ),
       ),

--- a/example/lib/src/storybook/storybook.dart
+++ b/example/lib/src/storybook/storybook.dart
@@ -59,7 +59,7 @@ class StorybookPage extends StatelessWidget {
         ),
         const Align(
           alignment: Alignment.bottomCenter,
-          child: MoonVersionWidget(version: "0.1.0"),
+          child: MoonVersionWidget(),
         ),
       ],
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -161,7 +161,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   nested:
     dependency: transitive
     description:


### PR DESCRIPTION
Get and show MDS version dynamically in storybook.