### PR TITLE
feat: add propagateGesturesToChild to the MoonButton

### DIFF
--- a/lib/src/widgets/buttons/button.dart
+++ b/lib/src/widgets/buttons/button.dart
@@ -48,6 +48,9 @@ class MoonButton extends StatefulWidget {
   /// Whether to show a scale effect when the button is tapped or long-pressed.
   final bool showScaleEffect;
 
+  /// Whether to propagate gestures to the child of the base control.
+  final bool propagateGesturesToChild;
+
   /// The border radius of the button.
   final BorderRadiusGeometry? borderRadius;
 
@@ -172,6 +175,7 @@ class MoonButton extends StatefulWidget {
     this.showPulseEffect = false,
     this.showPulseEffectJiggle = true,
     this.showScaleEffect = true,
+    this.propagateGesturesToChild = false,
     this.borderRadius,
     this.backgroundColor,
     this.borderColor,
@@ -227,6 +231,7 @@ class MoonButton extends StatefulWidget {
     this.showPulseEffect = false,
     this.showPulseEffectJiggle = true,
     this.showScaleEffect = true,
+    this.propagateGesturesToChild = false,
     this.borderRadius,
     this.backgroundColor,
     this.borderColor,
@@ -378,6 +383,7 @@ class _MoonButtonState extends State<MoonButton> with SingleTickerProviderStateM
       showPulseEffect: widget.showPulseEffect,
       showPulseEffectJiggle: widget.showPulseEffectJiggle,
       showScaleEffect: widget.showScaleEffect,
+      propagateGesturesToChild: widget.propagateGesturesToChild,
       borderRadius: effectiveBorderRadius,
       backgroundColor: widget.backgroundColor,
       focusEffectColor: widget.focusEffectColor,


### PR DESCRIPTION
Hello,

first of all, thank you for a great package. If you prefer to create an issue first, please let me know. And sorry if I broke conventional commits, I hope everything is fine though :)

Why do we need this property?
we use [patrol_finders](https://pub.dev/packages/patrol_finders) in our project. However, patroltester's [tap()](https://github.com/leancodepl/patrol/blob/67f901586afc441d3e448f954596a19ff16d81b1/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart#L240) method has custom logic which based on [hitTestable()](https://github.com/leancodepl/patrol/blob/67f901586afc441d3e448f954596a19ff16d81b1/packages/patrol_finders/lib/src/custom_finders/patrol_tester.dart#L405). So when we find a widget by MoonButton's child (e.g. by text) we can't tap on it because MoonBaseControl absorbs the interaction.

If you want to play with it there is a [sample](https://github.com/trejdych/patrol_moon/blob/main/test/widget_test.dart) repository. The last test 'moonbutton patrol' fails